### PR TITLE
get_projects_stats.sql: avoid null violation for percentages

### DIFF
--- a/sql/get_projects_stats.sql
+++ b/sql/get_projects_stats.sql
@@ -37,8 +37,8 @@ WITH stats AS (
 )
 SELECT
     *,
-    CAST(1.0 * total_seconds / nullif (sum(total_seconds) OVER (), 0) AS numeric) AS pct,
-    CAST(1.0 * total_seconds / nullif (sum(total_seconds) OVER (PARTITION BY day), 0) AS numeric) AS daily_pct
+    coalesce(CAST(1.0 * total_seconds / nullif (sum(total_seconds) OVER (), 0) AS numeric), 0) AS pct,
+    coalesce(CAST(1.0 * total_seconds / nullif (sum(total_seconds) OVER (PARTITION BY day), 0) AS numeric), 0) AS daily_pct
 FROM
     stats;
 


### PR DESCRIPTION
Hey, thanks for this project - it's amazing!

I ran into some issues with the backend call crashing on the Projects page due to [non-null violations](https://github.com/williamboman/hakatime/blob/fix-null-violation/src/Haka/Db/Statements.hs#L341-L348) in the decoder for projects stats. I did some digging and it turned out that the `daily_pct` column would return null in a particular case because of `nullif (sum(total_seconds) OVER (PARTITION BY day), 0)`. I could share the raw data, if you're interested.