### PR TITLE
Error sending data from Atom plugin v9.0.2 and v10.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ instance.
 (builds on every commit) or with `mujx/hakatime:latest-arm` (manual semi-regular updates for `arm/v7` & `arm64`)
 or by building the image yourself with the dedicated Dockerfile (`Dockerfile.arm`).
 
+**WARNING**: This setup relies on `./docker` directory located in this repository, please run it after making `git clone` to evade issues.
+
 ```yaml
 version: "3"
 services:

--- a/sql/insert_heartbeat.sql
+++ b/sql/insert_heartbeat.sql
@@ -22,7 +22,7 @@ INSERT INTO heartbeats
 
 VALUES ( $1, $2, $3, $4, $5,
          $6, $7, $8, $9, $10,
-         $11, $12, $13, $14, $15,
+         $11, $12, $13, CAST($14 AS INT), $15,
          $16, $17, $18 )
 
 RETURNING "id";

--- a/src/Haka/Db/Statements.hs
+++ b/src/Haka/Db/Statements.hs
@@ -359,7 +359,7 @@ insertHeartBeat = Statement query params result True
         <> (entity >$< E.param (E.nonNullable E.text))
         <> (is_write >$< E.param (E.nullable E.bool))
         <> (language >$< E.param (E.nullable E.text))
-        <> (lineno >$< E.param (E.nullable E.int8))
+        <> (lineno >$< E.param (E.nullable E.text))
         <> (file_lines >$< E.param (E.nullable E.int8))
         <> (project >$< E.param (E.nullable E.text))
         <> (ty >$< E.param (E.nonNullable entityValue))

--- a/src/Haka/Types.hs
+++ b/src/Haka/Types.hs
@@ -377,7 +377,7 @@ data HeartbeatPayload = HeartbeatPayload
     is_write :: Maybe Bool,
     -- | The language used by the entity.
     language :: Maybe Text,
-    lineno :: Maybe Int64,
+    lineno :: Maybe Text,
     -- | Total number of lines for the entity.
     file_lines :: Maybe Int64,
     -- | Name of the project.


### PR DESCRIPTION
So I saw code 400 while sending data to precious hakatime from my Atom plugin. Upgrading from v9.0.2 to v10.0.0 makes no difference.

The error was following:

```
{"now": "2021/01/24 02:32:33 +0300", "version": "13.0.7", "plugin": "atom-wakatime/10.0.0", "time": 1611444753.4426773, "caller": "wakatime/api.py", "lineno": 334, "is_write": true, "file": "/<redacted-path-to-yml-file>", "level": "ERROR", "message": "{'response_code': 400, 'response_content': '{\"error\":\"Bad Request\",\"message\":\"Error in $[0].lineno: parsing Int64 failed, expected Number, but encountered String\"}'}"}
```

I checked #11 and applied same patch. Sadly, I wasn't quite realizing what I am doing, so would be awesome if you review it first :smile_cat: 

It also likely that I've faced same issue as in #1, #10 and #15, so I decided to add small mention to readme, saying the `docker-compose` relies on local `./docker` directory, so we need to clone repo first, not just copy-paste `docker-compose.yml` itself.