### PR TITLE
Fix for wrong docker version in Readme.md and docker-compose-deploy.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ version: "3"
 services:
   server:
     container_name: hakatime
-    image: mujx/hakatime:1.5.0
+    image: mujx/hakatime:v1.5.0
     environment:
       # DB settings.
       HAKA_DB_HOST: haka_db

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   server:
     container_name: hakatime
-    image: mujx/hakatime:1.5.0
+    image: mujx/hakatime:v1.5.0
     environment:
       # DB settings.
       HAKA_DB_HOST: haka_db


### PR DESCRIPTION
Examples of docker-compose.yml in Readme.md are not working since the version of docker image (1.5.0) doesn't exist, it is actually labeled with v1.5.0.