### PR TITLE
Add `url` heartbeat type

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -16,7 +16,7 @@ RUN yarn run prod && rm -rf .git
 #
 # Build the server.
 #
-FROM ubuntu:20.10 as server-builder
+FROM ubuntu:21.04 as server-builder
 
 WORKDIR /build
 
@@ -41,7 +41,7 @@ RUN cabal configure --disable-optimization && \
     cabal build -j2 exe:hakatime && mkdir -p /app/bin && \
     cp /build/dist-newstyle/build/*-linux/ghc-*/hakatime-*/x/hakatime/opt/build/hakatime/hakatime /app/bin/hakatime
 
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/src/Haka/Db/Statements.hs
+++ b/src/Haka/Db/Statements.hs
@@ -379,6 +379,7 @@ insertHeartBeat = Statement query params result True
         entityText FileType = "file"
         entityText AppType = "app"
         entityText DomainType = "domain"
+        entityText UrlType = "url"
 
 getProjectStats :: Statement (Text, Text, UTCTime, UTCTime, Int64) [ProjectStatRow]
 getProjectStats = Statement query params result True

--- a/src/Haka/Types.hs
+++ b/src/Haka/Types.hs
@@ -241,7 +241,7 @@ data HeartbeatPayload = HeartbeatPayload
     file_lines :: Maybe Int64,
     -- | Name of the project.
     project :: Maybe Text,
-    -- | Type of the entity that triggered the heartbeat (file, app, domain)
+    -- | Type of the entity that triggered the heartbeat (file, app, domain, url)
     ty :: EntityType,
     -- | Unix timestamp for when the heartbeat was generated.
     time_sent :: Double
@@ -254,7 +254,7 @@ instance FromJSON HeartbeatPayload where
 instance ToJSON HeartbeatPayload where
   toJSON = genericToJSON convertReservedWords
 
-data EntityType = FileType | AppType | DomainType
+data EntityType = FileType | AppType | DomainType | UrlType
   deriving (Eq, Show, Generic)
 
 instance FromJSON EntityType where
@@ -262,13 +262,15 @@ instance FromJSON EntityType where
     "file" -> return FileType
     "app" -> return AppType
     "domain" -> return DomainType
-    _ -> fail "Value can only be one of ['file', 'app', 'domain']"
+    "url" -> return UrlType
+    _ -> fail "Value can only be one of ['file', 'app', 'domain', 'url']"
   parseJSON _ = fail "Expected a string value"
 
 instance ToJSON EntityType where
   toJSON FileType = A.String "file"
   toJSON AppType = A.String "app"
   toJSON DomainType = A.String "domain"
+  toJSON UrlType = A.String "url"
 
 data LeaderboardRow = LeaderboardRow
   { leadProject :: Text,


### PR DESCRIPTION
This PR is an attempt to fix import error when data[0] type is `url`
Error message: `msg=json decoding failed: "Error in $.data[0].type: Value can only be one of ['file', 'app', 'domain']"`

If we look at the [docs](https://wakatime.com/developers#heartbeats), we'll see that is correct. However Wakatime Chrome plugin also sends `url` type. It is now missing in the docs.
Here is an example:
```
{
    "branch": null,
    "category": "browsing",
    "created_at": "2022-03-01T00:18:29Z",
    "cursorpos": null,
    "dependencies": [],
    "entity": "http://localhost:8060",
    "id": "9e4a69c0-a4d1-4c6e-9d06-75a4f586bc31",
    "is_write": null,
    "language": null,
    "lineno": null,
    "lines": null,
    "machine_name_id": "f13d8c4b-fd8d-43ab-87db-75cf06ccc303",
    "project": "frontend",
    "time": 1646093909.0,
    "type": "url",
    "user_agent_id": "1efe69f2-4c95-4c76-b778-d790901ecb86",
    "user_id": "d820e1be-34c6-423b-b5c1-9060fed2e97d"
}
```

I am not a haskell developer. That's why not quite sure if these changes are correct. 
~~I'll try to build an image and check if everything is working.~~
UPD. It now works great. However, I had to update ubuntu image for Dockerfile.arm up to 21.04 version.