### PR TITLE
fix: psql client not found in arm dockerfile

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -44,7 +44,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -qq && \
     apt-get install --no-install-recommends -y netcat libffi-dev libgmp-dev libpq-dev zlib1g-dev postgresql postgresql-client ca-certificates curl && \
-    apt-get remove -y perl && \
     apt-get autoremove -y && \
     apt-get autoclean && \
     rm -rf /usr/lib/x86_64-linux-gnu/libLLVM* /usr/lib/x86_64-linux-gnu/libicudata.so*


### PR DESCRIPTION
Postgresql client has a dependency to perl and removing perl also removes `psql` from the container image.

Attached logs from running `apt remove perl` from a container built with this patch:

    root@3c557f7743b3:/# apt remove perl
    Reading package lists... Done
    Building dependency tree... Done
    Reading state information... Done
    The following packages were automatically installed and are no longer required:
    libedit2 libgdbm-compat4 libgdbm6 libicu70 libllvm14 libperl5.34 libreadline8 libxml2 libxslt1.1 locales netbase perl-modules-5.34 readline-common ssl-cert tzdata ucf
    Use 'apt autoremove' to remove them.
    The following packages will be REMOVED:
    libjson-perl perl postgresql postgresql-14 postgresql-client postgresql-client-14 postgresql-client-common postgresql-common
    0 upgraded, 0 newly installed, 8 to remove and 0 not upgraded.
    After this operation, 49.2 MB disk space will be freed.
    Do you want to continue? [Y/n]

Related to https://github.com/mujx/hakatime/pull/68