### PR TITLE
Add nix flake to run with Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1680951535,
+        "narHash": "sha256-rWrpW/X/pt2WgfDiQTIjdZR77KJTblEu74qqNcJRtds=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "72cdc142b93cffbedc91001ae5c6e9059b03c60c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "72cdc142b93cffbedc91001ae5c6e9059b03c60c",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Hakatime";
+
+  inputs = {
+    nixpkgs.url =
+      "github:nixos/nixpkgs/72cdc142b93cffbedc91001ae5c6e9059b03c60c";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      formatter.${system} = pkgs.nixfmt;
+
+      packages.${system}.default =
+        pkgs.haskellPackages.callPackage ./default.nix { };
+
+      devShells.${system}.default =
+        pkgs.callPackage ./shell.nix { inherit pkgs; };
+
+      apps.${system}.default = {
+        type = "app";
+        program = "${self.packages.${system}.default}/bin/hakatime";
+      };
+    };
+}


### PR DESCRIPTION
Add a nix flake with a nixpkgs instance using the same rev as upstream.nix, a packages output building the default.nix, apps output using the hakatime executable from the packages output, a devShells output building the shell.nix, and finally a formatter output to correctly format the flake.